### PR TITLE
delete _getShareAllocations function

### DIFF
--- a/contracts/SuperDCAPoolV1.sol
+++ b/contracts/SuperDCAPoolV1.sol
@@ -694,15 +694,6 @@ contract SuperDCAPoolV1 is SuperAppBase, AutomateTaskCreator, SuperDCAPoolStakin
     (_timestamp, _flowRate,,) = cfa.getFlow(_superToken, _shareholder, address(this));
   }
 
-  function _getShareAllocations(ShareholderUpdate memory _shareholderUpdate)
-    internal
-    pure
-    returns (uint128 userShares)
-  {
-    // The user's shares will always be their current flow rate
-    userShares = ShareMathLib.flowRateToShares(_shareholderUpdate.currentFlowRate);
-  }
-
   function _calcUserUninvested(uint256 prevUpdateTimestamp, uint256 flowRate, uint256 lastDist)
     internal
     view

--- a/test/SuperDCAPoolV1.t.sol
+++ b/test/SuperDCAPoolV1.t.sol
@@ -87,8 +87,6 @@ contract SuperDCAPoolV1Test is Test {
   }
 
   function setUp() public {
-    string memory optimismRpc = vm.rpcUrl("optimism");
-    require(bytes(optimismRpc).length > 0, "Missing RPC URL for optimism");
     vm.createSelectFork(vm.rpcUrl("optimism"), FORK_BLOCK_NUMBER);
 
     vm.startPrank(AUTHORIZED_DEPLOYER, AUTHORIZED_DEPLOYER);

--- a/test/SuperDCAPoolV1.t.sol
+++ b/test/SuperDCAPoolV1.t.sol
@@ -87,6 +87,8 @@ contract SuperDCAPoolV1Test is Test {
   }
 
   function setUp() public {
+    string memory optimismRpc = vm.rpcUrl("optimism");
+    require(bytes(optimismRpc).length > 0, "Missing RPC URL for optimism");
     vm.createSelectFork(vm.rpcUrl("optimism"), FORK_BLOCK_NUMBER);
 
     vm.startPrank(AUTHORIZED_DEPLOYER, AUTHORIZED_DEPLOYER);


### PR DESCRIPTION
I deleted `SuperDCAPoolV1::_getShareAllocations` function because it is not called by any other functoins in the contract